### PR TITLE
Mention in readme that neuralcoref still needs to be installed when using models

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -66,6 +66,7 @@ environment to avoid modifying system state:
     source .env/bin/activate
     pip install MODEL_URL
 
+You will also need to install the NeuralCoref library as described below.
 
 Install NeuralCoref from source
 -------------------------------


### PR DESCRIPTION
At our place new people got confused when trying to use the spacy models approach led to "module not found" errors.

They assumed that when using spacy models one did not have to install NeuralCoref separately.
Might be easier if the README mentioned that NeuralCoref still needs to be installed when using models.