### PR TITLE
Makes prediction work on GPUs

### DIFF
--- a/neuralcoref/neuralcoref.pyx
+++ b/neuralcoref/neuralcoref.pyx
@@ -892,16 +892,8 @@ cdef class NeuralCoref(object):
         return self.get_word_embedding(sent.doc[i])
 
     def get_average_embedding(self, Span span):
-        cdef int i
-        cdef int n = 0
-        embed_arr = numpy.zeros(self.static_vectors.shape[1], dtype='float32')
-        for token in span:
-            if token.lower not in PUNCTS:
-                n += 1
-                embed_vector = self.get_word_embedding(token, tuned=False)
-                embed_arr = embed_arr + embed_vector
-        embed_arr = numpy.divide(embed_arr, float(max(n, 1)))
-        return embed_arr
+        tokens = [token for token in span if token.lower not in PUNCTS]
+        return sum(self.get_word_embedding(token, tuned=False) for token in tokens) / float(max(len(tokens), 1))
 
     def get_mention_embeddings(self, Span span, doc_embedding):
         ''' Create a mention embedding with span (averaged) and word (single) embeddings '''

--- a/neuralcoref/neuralcoref.pyx
+++ b/neuralcoref/neuralcoref.pyx
@@ -20,7 +20,12 @@ import array
 from libc.stdint cimport uint16_t, uint32_t, uint64_t, uintptr_t, int32_t
 
 import numpy
-import cupy
+try:
+    import cupy
+    to_numpy = cupy.asnumpy
+except ModuleNotFoundError:
+    to_numpy = lambda x: x
+
 from thinc.neural.util import get_array_module
 from cymem.cymem cimport Pool
 from srsly import json_dumps, read_json
@@ -764,11 +769,11 @@ cdef class NeuralCoref(object):
             best_ant_ar = numpy.empty((n_mentions), dtype=numpy.uint64)
             best_score = best_score_ar
             best_ant = best_ant_ar
-            s_score = cupy.asnumpy(self.model[0](xp.asarray(s_inp_arr)))
+            s_score = to_numpy(self.model[0](xp.asarray(s_inp_arr)))
             for i in range(n_mentions):
                 best_score[i] = s_score[i, 0] - 50 * (greedyness - 0.5)
                 best_ant[i] = i
-            p_score = cupy.asnumpy(self.model[1](xp.asarray(p_inp_arr)))
+            p_score = to_numpy(self.model[1](xp.asarray(p_inp_arr)))
             for i in range(n_pairs):
                 ant_idx = p_ant[i]
                 men_idx = p_men[i]

--- a/neuralcoref/neuralcoref.pyx
+++ b/neuralcoref/neuralcoref.pyx
@@ -729,7 +729,7 @@ cdef class NeuralCoref(object):
             doc_c = doc.c
             doc_embedding = xp.zeros(SIZE_EMBEDDING, dtype='float32') # self.embeds.get_average_embedding(doc.c, 0, doc.length + 1, self.hashes.puncts)
             for i in range(n_mentions):
-                s_inp_arr[i, :SGNL_FEATS_0] = self.get_mention_embeddings(mentions[i], doc_embedding) # Set embeddings
+                s_inp_arr[i, :SGNL_FEATS_0] = to_numpy(self.get_mention_embeddings(mentions[i], doc_embedding)) # Set embeddings
                 s_inp_arr[i, SGNL_FEATS_0 + c[i].mention_type] = 1                      # 01_MentionType
                 b_idx, val = index_distance(c[i].span_end - c[i].span_start - 1)    # 02_MentionLength
                 s_inp_arr[i, SGNL_FEATS_1 + b_idx] = 1


### PR DESCRIPTION
When you use `numpy.zeros` to create the `embed_arr`, you can't later add it to `embed_vector`, because `embed_vector` might not be a numpy array. This re-works the code such that the array type of `embed_vector` is preserved all the way through.

I stole this approach from https://github.com/explosion/spaCy/pull/3362. Thanks, @danielkingai2!