### PR TITLE
Update server example and readme - fix #150

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,25 @@ doc._.coref_clusters
 
 A simple example of server script for integrating NeuralCoref in a REST API is provided as an example in [`examples/server.py`](examples/server.py).
 
+To use it you need to install falcon first:
+
+```bash
+pip install falcon
+```
+
+You can then start the server as follows:
+
+```bash
+cd examples
+python ./server.py
+```
+
+And query the server like this:
+
+```bash
+curl --data-urlencode "text=My sister has a dog. She loves him." -G localhost:8000
+```
+
 There are many other ways you can manage and deploy NeuralCoref. Some examples can be found in [spaCy Universe](https://spacy.io/universe/).
 
 ## Re-train the model / Extend to another language

--- a/examples/server.py
+++ b/examples/server.py
@@ -10,6 +10,7 @@ import json
 from wsgiref.simple_server import make_server
 import falcon
 import spacy
+import neuralcoref
 
 try:
     unicode_ = unicode  # Python 2
@@ -19,7 +20,8 @@ except NameError:
 
 class AllResource(object):
     def __init__(self):
-        self.nlp = spacy.load('en_coref_sm')
+        self.nlp = spacy.load('en')
+        neuralcoref.add_to_pipe(self.nlp)
         print("Server loaded")
         self.response = None
 
@@ -27,6 +29,7 @@ class AllResource(object):
         self.response = {}
 
         text_param = req.get_param_as_list("text")
+        print("text: ", text_param)
         if text_param is not None:
             text = ",".join(text_param) if isinstance(text_param, list) else text_param
             text = unicode_(text)


### PR DESCRIPTION
Update the `server.py` example to be compatible with NeuralCoref 4.0.
Add a usage section in the readme for `server.py`.