### PR TITLE
Fixes #204

### DIFF
--- a/neuralcoref/__init__.py
+++ b/neuralcoref/__init__.py
@@ -27,7 +27,7 @@ if os.path.exists(NEURALCOREF_MODEL_PATH) and os.path.exists(
     local_model = cached_path(NEURALCOREF_MODEL_PATH)
 else:
     if not os.path.exists(NEURALCOREF_MODEL_PATH):
-        os.makedirs(NEURALCOREF_MODEL_PATH)
+        os.makedirs(NEURALCOREF_MODEL_PATH, exist_ok=True)
     logger.info(f"Getting model from {NEURALCOREF_MODEL_URL} or cache")
     downloaded_model = cached_path(NEURALCOREF_MODEL_URL)
 

--- a/neuralcoref/__init__.py
+++ b/neuralcoref/__init__.py
@@ -24,7 +24,7 @@ if os.path.exists(NEURALCOREF_MODEL_PATH) and os.path.exists(os.path.join(NEURAL
     local_model = cached_path(NEURALCOREF_MODEL_PATH)
 else:
     if not os.path.exists(NEURALCOREF_MODEL_PATH):
-        os.makedirs(NEURALCOREF_MODEL_PATH)
+        os.makedirs(NEURALCOREF_MODEL_PATH, exist_ok=True)
     logger.info("Getting model from {} or cache".format(NEURALCOREF_MODEL_URL))
     downloaded_model = cached_path(NEURALCOREF_MODEL_URL)
 


### PR DESCRIPTION
Add  [`exist_ok=True`](https://docs.python.org/3/library/os.html#os.makedirs) to the directory creation command of `NEURALCOREF_MODEL_PATH` to avoid raising `FileExistsError` if the target directory already exists, which is the default behavior (`exist_ok=False`).

This argument requires Python >=3.2. [README](https://github.com/huggingface/neuralcoref/blob/master/README.md) of neuralcoef mentions that Python 3.5+ is required. However, Neuralcoef's [`setup.py`](https://github.com/huggingface/neuralcoref/blob/master/setup.py#L235) is saying that, for example, Python 2.7 could be used as well. Which one is right?