### PR TITLE
Fix issue #241: Wrong datatype in error message

### DIFF
--- a/neuralcoref/train/conllparser.py
+++ b/neuralcoref/train/conllparser.py
@@ -348,7 +348,7 @@ class ConllDoc(Document):
         # Convert conll tokens coref index in spacy tokens indexes
         identified_gold = [False] * len(corefs)
         for coref in corefs:
-            missing_values = [key for key in ['label', 'start', 'end', ] if coref[key] is None]
+            missing_values = [key for key in ['label', 'start', 'end', ] if coref.get(key, None) is None]
             if missing_values:
                 found_values = {key: coref[key] for key in ['label', 'start', 'end'] if coref[key] is not None}
                 raise Exception(f"Coref {str(found_values)} with empty field(s) {', '.join(missing_values)} found in {self.name}")

--- a/neuralcoref/train/conllparser.py
+++ b/neuralcoref/train/conllparser.py
@@ -351,7 +351,7 @@ class ConllDoc(Document):
             missing_values = [key for key in ['label', 'start', 'end', ] if coref.get(key, None) is None]
             if missing_values:
                 found_values = {key: coref[key] for key in ['label', 'start', 'end'] if coref.get(key, None) is not None}
-                raise Exception(f"Coref {str(found_values)} with empty field(s) {', '.join(missing_values)} found in {self.name}")
+                raise Exception(f"Coref {self.name} with fields {found_values} has empty values for the keys {missing_values}.")
 
             coref["start"] = conll_lookup[coref["start"]][0]
             coref["end"] = conll_lookup[coref["end"]][-1]

--- a/neuralcoref/train/conllparser.py
+++ b/neuralcoref/train/conllparser.py
@@ -348,11 +348,11 @@ class ConllDoc(Document):
         # Convert conll tokens coref index in spacy tokens indexes
         identified_gold = [False] * len(corefs)
         for coref in corefs:
-            assert (
-                coref["label"] is not None
-                and coref["start"] is not None
-                and coref["end"] is not None
-            ), ("Error in coreference " + coref + " in " + parsed)
+            missing_values = [key for key in ['label', 'start', 'end', ] if coref[key] is None]
+            if missing_values:
+                found_values = {key: coref[key] for key in ['label', 'start', 'end'] if coref[key] is not None}
+                raise Exception(f"Coref {str(found_values)} with empty field(s) {', '.join(missing_values)} found in {self.name}")
+
             coref["start"] = conll_lookup[coref["start"]][0]
             coref["end"] = conll_lookup[coref["end"]][-1]
 

--- a/neuralcoref/train/conllparser.py
+++ b/neuralcoref/train/conllparser.py
@@ -350,7 +350,7 @@ class ConllDoc(Document):
         for coref in corefs:
             missing_values = [key for key in ['label', 'start', 'end', ] if coref.get(key, None) is None]
             if missing_values:
-                found_values = {key: coref[key] for key in ['label', 'start', 'end'] if coref[key] is not None}
+                found_values = {key: coref[key] for key in ['label', 'start', 'end'] if coref.get(key, None) is not None}
                 raise Exception(f"Coref {str(found_values)} with empty field(s) {', '.join(missing_values)} found in {self.name}")
 
             coref["start"] = conll_lookup[coref["start"]][0]


### PR DESCRIPTION
Correct assertion error when CoNLL parser fails and expand error
message.

This also adds the document name and fields with values to the error message to help with debugging.