### PR TITLE
Update requirements.txt to update spacy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-spacy>=2.1.0,<2.2.0
+spacy>=2.1.0
 cython>=0.25
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-spacy>=2.1.0
+spacy>=2.1.0,<3.0.0
 cython>=0.25
 pytest


### PR DESCRIPTION
Removed the restriction to install only for <`spacy 2.2.0`. The library works well even in the case of `spacy 2.2.4`. Earlier it used to give an error for `ERROR: en-core-web-md 2.2.5 has requirement spacy>=2.2.2, but you'll have spacy 2.1.9 which is incompatible.` 

Due to this, I propose the following change of updating the spacy version.