### PR TITLE
Modify spaCy download code

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Here is an example of how you can install SpaCy and a (small) English model for 
 
 ```bash
 pip install -U spacy
-python -m spacy download en
+python -m spacy download en_core_web_sm
 ```
 
 ### Install NeuralCoref from source


### PR DESCRIPTION
Current download code results in a warning message within the log. This commit makes the model to download more specific.

**Warning message in log**

> ⚠ As of spaCy v3.0, shortcuts like 'en' are deprecated. Please use the full pipeline package name 'en_core_web_sm' instead.